### PR TITLE
Delete the use of the non-extisting class Twig_Autoloader for Twig 2.X

### DIFF
--- a/Twig.php
+++ b/Twig.php
@@ -109,15 +109,7 @@ class Twig extends \Slim\View
     public function getInstance()
     {
         if (!$this->parserInstance) {
-            /**
-             * Check if Twig_Autoloader class exists
-             * otherwise include it.
-             */
-            if (!class_exists('\Twig_Autoloader')) {
-                require_once $this->parserDirectory . '/Autoloader.php';
-            }
-
-            \Twig_Autoloader::register();
+            // With Twig 2.X Use Composer Loader. Don't use anymore a Twig_Autoloader class
             $loader = new \Twig_Loader_Filesystem($this->getTemplateDirs());
             $this->parserInstance = new \Twig_Environment(
                 $loader,

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     ],
     "require": {
         "slim/slim": ">=2.4.0",
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "twig/twig": ">=2.0.0"
     },
     "suggest": {
         "smarty/smarty": "Smarty templating system",


### PR DESCRIPTION
Set compatibility with Twig 2.X